### PR TITLE
Make compatible with python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,4 +24,7 @@ setup(
     download_url="https://github.com/alexmgr/tinyec/archive/v0.3.1.tar.gz",
     long_description=read_("README.md"),
     test_suite="nose.collector",
-    tests_require=["nose"])
+    tests_require=["nose"],
+    classifiers=[
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3"])

--- a/test/test_ec.py
+++ b/test/test_ec.py
@@ -87,13 +87,18 @@ class TestPoint(unittest.TestCase):
 
     def test_when_point_is_not_multiplied_by_an_int_then_error_is_raised(self):
         p1 = ec.Point(self.curve, 3, 6)
-        with self.assertRaises(TypeError):
+        with self.assertRaises(TypeError) as contextMgr:
             p1 * p1
+
+        tErr = contextMgr.exception
+        self.assertRegexpMatches(tErr.message, "Unsupported operand type\\(s\\) for \\*\\: \'Point\' and \'Point\'", "Unexpected TypeError message - did the message change or this being thrown from a different location?")
 
     def test_python3_compat_when_point_is_not_multiplied_by_int_or_point_then_error_is_raised(self):
         p1 = ec.Point(self.curve, 3, 6)
-        with self.assertRaises(TypeError):
+        with self.assertRaises(TypeError) as contextMgr:
             p1 * 5.6
+        tErr = contextMgr.exception
+        self.assertRegexpMatches(tErr.message, "Unsupported operand type\\(s\\) for \\*\\: \'float\' and \'Point\'", "Unexpected TypeError message - did the message change or this being thrown from a different location?")
 
 class TestKeyPair(unittest.TestCase):
     def setUp(self):

--- a/test/test_ec.py
+++ b/test/test_ec.py
@@ -90,6 +90,10 @@ class TestPoint(unittest.TestCase):
         with self.assertRaises(TypeError):
             p1 * p1
 
+    def test_python3_compat_when_point_is_not_multiplied_by_int_or_point_then_error_is_raised(self):
+        p1 = ec.Point(self.curve, 3, 6)
+        with self.assertRaises(TypeError):
+            p1 * 5.6
 
 class TestKeyPair(unittest.TestCase):
     def setUp(self):

--- a/test/test_ec.py
+++ b/test/test_ec.py
@@ -91,14 +91,14 @@ class TestPoint(unittest.TestCase):
             p1 * p1
 
         tErr = contextMgr.exception
-        self.assertRegexpMatches(tErr.message, "Unsupported operand type\\(s\\) for \\*\\: \'Point\' and \'Point\'", "Unexpected TypeError message - did the message change or this being thrown from a different location?")
+        self.assertRegexpMatches(str(tErr), "Unsupported operand type\\(s\\) for \\*\\: \'Point\' and \'Point\'", "Unexpected TypeError message - did the message change or this being thrown from a different location?")
 
     def test_python3_compat_when_point_is_not_multiplied_by_int_or_point_then_error_is_raised(self):
         p1 = ec.Point(self.curve, 3, 6)
         with self.assertRaises(TypeError) as contextMgr:
             p1 * 5.6
         tErr = contextMgr.exception
-        self.assertRegexpMatches(tErr.message, "Unsupported operand type\\(s\\) for \\*\\: \'float\' and \'Point\'", "Unexpected TypeError message - did the message change or this being thrown from a different location?")
+        self.assertRegexpMatches(str(tErr), "Unsupported operand type\\(s\\) for \\*\\: \'float\' and \'Point\'", "Unexpected TypeError message - did the message change or this being thrown from a different location?")
 
 class TestKeyPair(unittest.TestCase):
     def setUp(self):

--- a/tinyec/ec.py
+++ b/tinyec/ec.py
@@ -95,7 +95,7 @@ class Inf(object):
             return Inf()
         if isinstance(other, Point):
             return other
-        raise TypeError("Unsupported operand type(s) for +: '%s' and '%s'" % (q.__class__.__name__,
+        raise TypeError("Unsupported operand type(s) for +: '%s' and '%s'" % (other.__class__.__name__,
                                                                                   self.__class__.__name__))
 
     def __sub__(self, other):
@@ -103,7 +103,7 @@ class Inf(object):
             return Inf()
         if isinstance(other, Point):
             return other
-        raise TypeError("Unsupported operand type(s) for +: '%s' and '%s'" % (q.__class__.__name__,
+        raise TypeError("Unsupported operand type(s) for +: '%s' and '%s'" % (other.__class__.__name__,
                                                                                   self.__class__.__name__))
 
     def __str__(self):

--- a/tinyec/ec.py
+++ b/tinyec/ec.py
@@ -160,9 +160,11 @@ class Point(object):
                                                                                   self.__class__.__name__))
 
     def __mul__(self, other):
-        if isinstance(other, Inf) or other % self.curve.field.n == 0:
+        if isinstance(other, Inf):
             return Inf(self.curve)
         if isinstance(other, int) or isinstance(other, long):
+            if other % self.curve.field.n == 0:
+                return Inf(self.curve)
             if other < 0:
                 addend = Point(self.curve, self.x, -self.y % self.p)
             else:

--- a/tinyec/ec.py
+++ b/tinyec/ec.py
@@ -3,6 +3,11 @@ import random
 
 import warnings
 
+# Python3 compatibility
+try:
+    LONG_TYPE = long
+except NameError:
+    LONG_TYPE = int
 
 def egcd(a, b):
     if a == 0:
@@ -162,7 +167,7 @@ class Point(object):
     def __mul__(self, other):
         if isinstance(other, Inf):
             return Inf(self.curve)
-        if isinstance(other, int) or isinstance(other, long):
+        if isinstance(other, int) or isinstance(other, LONG_TYPE):
             if other % self.curve.field.n == 0:
                 return Inf(self.curve)
             if other < 0:


### PR DESCRIPTION
Hi Alex,

Thanks so much for creating this library. It really helped me to learn elliptic curve crypto math. However, I found that it's not fully compatible with python3 due to the use of the long type (which has been subsumed into the int type in python3). I put together a set of changes here to try and help:
   - Add a test that demos the compatibility issue (run with `python3 setup.py test` to see the failure)
   - Update the tests to correctly check for the specific TypeError thrown by your code (the old tests were catching the error where you try to do `% curve.n` with a non-integer value)
   - Avoid the `% curve.n` error
   - Add a bit of code to handle being in Python3 rather than 2 (should work with both versions)
   - Change setup.py to be more specific on the Python versions supported
   - Fix a couple of other bugs that my linting caught

Hopefully you think this is a useful addition to merge in. If there's anything you want updating, I don't mind contributing some time to improve the library further, let me know.

All the best,

Byron